### PR TITLE
Add SubTrackr Manifest V3 extension

### DIFF
--- a/subtrackr-extension/background.js
+++ b/subtrackr-extension/background.js
@@ -1,0 +1,93 @@
+// background.js (service worker)
+// Coordinates messages between content scripts and the popup while persisting data locally.
+
+import { saveSubscription } from './utils/db.js';
+
+// Maintain per-tab detections so we can surface the latest prompt in the popup.
+const pendingDetections = new Map();
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  // Wrap logic in an async IIFE so we can await Chrome APIs cleanly.
+  (async () => {
+    switch (message.type) {
+      case 'subscription-detected': {
+        const tabId = sender.tab?.id;
+        if (!tabId) {
+          sendResponse({ acknowledged: false });
+          return;
+        }
+
+        const detection = {
+          id: `${tabId}-${Date.now()}`,
+          serviceName: message.payload.serviceName,
+          detectedText: message.payload.detectedText,
+          timestamp: message.payload.timestamp,
+        };
+
+        pendingDetections.set(tabId, detection);
+        await chrome.storage.session.set({ [`tab-${tabId}`]: detection });
+
+        // Ask the content script to show the banner prompt immediately.
+        await chrome.tabs.sendMessage(tabId, {
+          type: 'show-detection',
+          detection,
+        });
+
+        sendResponse({ acknowledged: true });
+        break;
+      }
+      case 'save-subscription': {
+        const record = message.record;
+        const tabId = sender.tab?.id ?? message.tabId ?? null;
+        await saveSubscription(record);
+        if (tabId !== null) {
+          pendingDetections.delete(tabId);
+          await chrome.storage.session.remove(`tab-${tabId}`);
+        }
+
+        // Notify the sender tab that the save completed so the UI can update.
+        if (tabId !== null) {
+          await chrome.tabs.sendMessage(tabId, {
+            type: 'subscription-saved',
+            id: record.id,
+          });
+        }
+
+        sendResponse({ saved: true });
+        break;
+      }
+      case 'clear-pending': {
+        const tabId = sender.tab?.id ?? message.tabId ?? null;
+        if (tabId !== null) {
+          pendingDetections.delete(tabId);
+          await chrome.storage.session.remove(`tab-${tabId}`);
+        }
+        sendResponse({ cleared: true });
+        break;
+      }
+      case 'get-latest-detection': {
+        // Identify the active tab to surface any pending detection information.
+        const [activeTab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+        const tabId = activeTab?.id;
+        let detection = tabId ? pendingDetections.get(tabId) : null;
+
+        if (!detection && tabId) {
+          const stored = await chrome.storage.session.get(`tab-${tabId}`);
+          detection = stored[`tab-${tabId}`] || null;
+        }
+
+        sendResponse({ detection, tabId: tabId ?? null });
+        break;
+      }
+      default: {
+        sendResponse({ handled: false });
+      }
+    }
+  })().catch((error) => {
+    console.error('SubTrackr background error:', error);
+    sendResponse({ error: error.message });
+  });
+
+  // Indicate that we will respond asynchronously once the async IIFE completes.
+  return true;
+});

--- a/subtrackr-extension/content.js
+++ b/subtrackr-extension/content.js
@@ -1,0 +1,182 @@
+// content.js
+// Detects subscription-related interactions and surfaces an inline banner for user consent.
+
+const KEYWORDS = [
+  'subscribe',
+  'subscription',
+  'plan',
+  'billing',
+  'free trial',
+  'manage subscription',
+  'upgrade',
+].map((keyword) => keyword.toLowerCase());
+
+let bannerElement = null;
+let currentDetection = null;
+let successTimeoutId = null;
+
+/**
+ * Quickly checks whether the provided text contains any subscription keyword.
+ * @param {string} text
+ * @returns {boolean}
+ */
+function matchesKeywords(text) {
+  if (!text) return false;
+  const normalized = text.toLowerCase();
+  return KEYWORDS.some((keyword) => normalized.includes(keyword));
+}
+
+/**
+ * Safely extracts the visible text content from an element without touching inputs.
+ * @param {Element} element
+ */
+function extractText(element) {
+  if (!element) return '';
+  if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) {
+    return element.value || '';
+  }
+  return (element.textContent || '').trim();
+}
+
+/**
+ * Sends a detection message to the background service worker.
+ * @param {string} detectedText
+ */
+function reportDetection(detectedText) {
+  const payload = {
+    serviceName: window.location.hostname,
+    detectedText,
+    timestamp: new Date().toISOString(),
+  };
+
+  chrome.runtime.sendMessage({ type: 'subscription-detected', payload });
+}
+
+/**
+ * Removes the banner and clears any timers.
+ */
+function dismissBanner() {
+  if (bannerElement?.parentNode) {
+    bannerElement.parentNode.removeChild(bannerElement);
+  }
+  bannerElement = null;
+  currentDetection = null;
+  if (successTimeoutId) {
+    clearTimeout(successTimeoutId);
+    successTimeoutId = null;
+  }
+}
+
+/**
+ * Builds (if necessary) and displays the floating consent banner.
+ * @param {object} detection
+ */
+function showBanner(detection) {
+  currentDetection = detection;
+
+  if (!bannerElement) {
+    bannerElement = document.createElement('div');
+    bannerElement.id = 'subtrackr-banner';
+    bannerElement.style.position = 'fixed';
+    bannerElement.style.bottom = '20px';
+    bannerElement.style.right = '20px';
+    bannerElement.style.zIndex = '2147483647';
+    bannerElement.style.background = '#1f2937';
+    bannerElement.style.color = '#f9fafb';
+    bannerElement.style.padding = '16px';
+    bannerElement.style.borderRadius = '8px';
+    bannerElement.style.boxShadow = '0 10px 30px rgba(15, 23, 42, 0.2)';
+    bannerElement.style.maxWidth = '320px';
+    bannerElement.style.fontFamily = 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
+
+    const message = document.createElement('div');
+    message.id = 'subtrackr-message';
+    message.style.marginBottom = '12px';
+    bannerElement.appendChild(message);
+
+    const actions = document.createElement('div');
+    actions.style.display = 'flex';
+    actions.style.gap = '8px';
+
+    const saveButton = document.createElement('button');
+    saveButton.textContent = 'Save';
+    saveButton.style.background = '#10b981';
+    saveButton.style.color = '#f9fafb';
+    saveButton.style.border = 'none';
+    saveButton.style.padding = '8px 14px';
+    saveButton.style.borderRadius = '6px';
+    saveButton.style.cursor = 'pointer';
+    saveButton.addEventListener('click', () => {
+      if (!currentDetection) return;
+      chrome.runtime.sendMessage({
+        type: 'save-subscription',
+        record: currentDetection,
+      });
+    });
+
+    const ignoreButton = document.createElement('button');
+    ignoreButton.textContent = 'Ignore';
+    ignoreButton.style.background = 'transparent';
+    ignoreButton.style.color = '#cbd5f5';
+    ignoreButton.style.border = '1px solid #4b5563';
+    ignoreButton.style.padding = '8px 14px';
+    ignoreButton.style.borderRadius = '6px';
+    ignoreButton.style.cursor = 'pointer';
+    ignoreButton.addEventListener('click', () => {
+      chrome.runtime.sendMessage({ type: 'clear-pending' });
+      dismissBanner();
+    });
+
+    actions.appendChild(saveButton);
+    actions.appendChild(ignoreButton);
+    bannerElement.appendChild(actions);
+  }
+
+  const messageElement = bannerElement.querySelector('#subtrackr-message');
+  if (messageElement) {
+    messageElement.textContent = `Detected possible subscription on ${detection.serviceName}. Save this subscription?`;
+  }
+
+  if (!bannerElement.parentNode) {
+    document.body.appendChild(bannerElement);
+  }
+}
+
+/**
+ * Evaluates clicks and submissions for subscription intent.
+ * @param {Event} event
+ */
+function handleInteraction(event) {
+  const target = event.target;
+  const submitter = event.submitter;
+
+  const candidateText = [extractText(submitter), extractText(target)]
+    .filter(Boolean)
+    .sort((a, b) => b.length - a.length)[0];
+
+  if (matchesKeywords(candidateText)) {
+    reportDetection(candidateText);
+  }
+}
+
+document.addEventListener('click', handleInteraction, true);
+document.addEventListener('submit', handleInteraction, true);
+
+// Listen for instructions from the background worker to display or hide UI feedback.
+chrome.runtime.onMessage.addListener((message) => {
+  if (message.type === 'show-detection') {
+    showBanner(message.detection);
+  }
+
+  if (message.type === 'subscription-saved') {
+    if (bannerElement) {
+      const messageElement = bannerElement.querySelector('#subtrackr-message');
+      if (messageElement) {
+        messageElement.textContent = 'Subscription saved locally.';
+      }
+      successTimeoutId = window.setTimeout(() => {
+        dismissBanner();
+      }, 1800);
+    }
+  }
+});

--- a/subtrackr-extension/manifest.json
+++ b/subtrackr-extension/manifest.json
@@ -1,0 +1,23 @@
+{
+  "manifest_version": 3,
+  "name": "SubTrackr",
+  "version": "1.0.0",
+  "description": "Detect and locally track subscription-related actions without collecting personal information.",
+  "permissions": ["activeTab", "storage", "scripting"],
+  "host_permissions": ["http://*/*", "https://*/*"],
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  },
+  "action": {
+    "default_title": "SubTrackr",
+    "default_popup": "popup.html"
+  },
+  "content_scripts": [
+    {
+      "matches": ["http://*/*", "https://*/*"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/subtrackr-extension/popup.html
+++ b/subtrackr-extension/popup.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SubTrackr</title>
+    <!-- Primary popup styles keep the UI compact and legible. -->
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <!-- Container element keeps layout consistent. -->
+    <main id="app">
+      <header>
+        <h1>SubTrackr</h1>
+        <p class="subtitle">Private subscription snapshots</p>
+      </header>
+
+      <!-- Detection panel shows the latest subscription prompt when available. -->
+      <section id="detection-panel" hidden>
+        <h2>Latest detection</h2>
+        <p id="detection-message"></p>
+        <div class="actions">
+          <button id="save-detection">Save</button>
+          <button id="ignore-detection" class="secondary">Ignore</button>
+        </div>
+      </section>
+
+      <!-- Status banner provides lightweight feedback after actions. -->
+      <div id="status" role="status" aria-live="polite"></div>
+
+      <!-- View saved button toggles the stored subscription list. -->
+      <button id="view-saved" class="full-width">View Saved</button>
+
+      <section id="saved-list" hidden>
+        <h2>Saved subscriptions</h2>
+        <ul id="records"></ul>
+        <button id="clear-all" class="danger">Delete All</button>
+      </section>
+    </main>
+
+    <script type="module" src="popup.js"></script>
+  </body>
+</html>

--- a/subtrackr-extension/popup.js
+++ b/subtrackr-extension/popup.js
@@ -1,0 +1,146 @@
+// popup.js
+// Handles UI interactions for reviewing detections and managing saved subscriptions.
+
+import { getSubscriptions, clearAll } from './utils/db.js';
+
+const detectionPanel = document.getElementById('detection-panel');
+const detectionMessage = document.getElementById('detection-message');
+const saveDetectionButton = document.getElementById('save-detection');
+const ignoreDetectionButton = document.getElementById('ignore-detection');
+const statusBanner = document.getElementById('status');
+const viewSavedButton = document.getElementById('view-saved');
+const savedListSection = document.getElementById('saved-list');
+const recordsList = document.getElementById('records');
+const clearAllButton = document.getElementById('clear-all');
+
+let latestDetection = null;
+let latestTabId = null;
+let savedListVisible = false;
+
+/**
+ * Updates the status banner with a short-lived message.
+ * @param {string} text
+ */
+function setStatus(text) {
+  statusBanner.textContent = text;
+  if (text) {
+    window.setTimeout(() => {
+      statusBanner.textContent = '';
+    }, 2200);
+  }
+}
+
+/**
+ * Requests the most recent detection for the active tab from the background worker.
+ */
+async function refreshDetection() {
+  try {
+    const response = await chrome.runtime.sendMessage({ type: 'get-latest-detection' });
+    latestDetection = response?.detection ?? null;
+    latestTabId = response?.tabId ?? null;
+
+    if (latestDetection) {
+      detectionMessage.textContent = `Detected possible subscription on ${latestDetection.serviceName}. Save this subscription?`;
+      detectionPanel.hidden = false;
+    } else {
+      detectionPanel.hidden = true;
+      detectionMessage.textContent = '';
+    }
+  } catch (error) {
+    console.error('SubTrackr popup detection error:', error);
+    setStatus('Unable to load detection.');
+  }
+}
+
+/**
+ * Fetches stored subscriptions and renders them in the list.
+ */
+async function renderSavedSubscriptions() {
+  try {
+    const subscriptions = await getSubscriptions();
+    recordsList.innerHTML = '';
+
+    if (!subscriptions.length) {
+      const emptyItem = document.createElement('li');
+      emptyItem.textContent = 'No subscriptions saved yet.';
+      recordsList.appendChild(emptyItem);
+      return;
+    }
+
+    subscriptions
+      .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
+      .forEach((record) => {
+        const item = document.createElement('li');
+        const title = document.createElement('span');
+        title.textContent = `${record.serviceName} — ${record.detectedText}`;
+
+        const time = document.createElement('span');
+        time.className = 'timestamp';
+        time.textContent = new Date(record.timestamp).toLocaleString();
+
+        item.appendChild(title);
+        item.appendChild(time);
+        recordsList.appendChild(item);
+      });
+  } catch (error) {
+    console.error('SubTrackr popup render error:', error);
+    setStatus('Unable to load saved subscriptions.');
+  }
+}
+
+saveDetectionButton.addEventListener('click', async () => {
+  if (!latestDetection || latestTabId === null) return;
+  try {
+    await chrome.runtime.sendMessage({
+      type: 'save-subscription',
+      record: latestDetection,
+      tabId: latestTabId,
+    });
+    setStatus('Subscription saved.');
+    latestDetection = null;
+    detectionPanel.hidden = true;
+    if (savedListVisible) {
+      await renderSavedSubscriptions();
+    }
+  } catch (error) {
+    console.error('SubTrackr save error:', error);
+    setStatus('Save failed.');
+  }
+});
+
+ignoreDetectionButton.addEventListener('click', async () => {
+  if (!latestDetection || latestTabId === null) return;
+  try {
+    await chrome.runtime.sendMessage({ type: 'clear-pending', tabId: latestTabId });
+    latestDetection = null;
+    detectionPanel.hidden = true;
+    setStatus('Detection ignored.');
+  } catch (error) {
+    console.error('SubTrackr ignore error:', error);
+    setStatus('Unable to ignore detection.');
+  }
+});
+
+viewSavedButton.addEventListener('click', async () => {
+  savedListVisible = !savedListVisible;
+  savedListSection.hidden = !savedListVisible;
+  viewSavedButton.textContent = savedListVisible ? 'Hide Saved' : 'View Saved';
+
+  if (savedListVisible) {
+    await renderSavedSubscriptions();
+  }
+});
+
+clearAllButton.addEventListener('click', async () => {
+  try {
+    await clearAll();
+    await renderSavedSubscriptions();
+    setStatus('All subscriptions deleted.');
+  } catch (error) {
+    console.error('SubTrackr clear error:', error);
+    setStatus('Unable to delete records.');
+  }
+});
+
+// Prime the popup with any pending detection as soon as it opens.
+refreshDetection();

--- a/subtrackr-extension/styles.css
+++ b/subtrackr-extension/styles.css
@@ -1,0 +1,109 @@
+/* styles.css
+ * Minimal styling that keeps the popup uncluttered and readable.
+ */
+
+:root {
+  color-scheme: light dark;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background-color: #0f172a;
+  color: #f8fafc;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  background: linear-gradient(160deg, #1e293b 0%, #0f172a 100%);
+}
+
+#app {
+  padding: 16px;
+}
+
+header {
+  margin-bottom: 12px;
+}
+
+h1 {
+  font-size: 1.2rem;
+  margin: 0 0 4px;
+}
+
+.subtitle {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #cbd5f5;
+}
+
+section {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 8px;
+  padding: 12px;
+  margin-bottom: 12px;
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+button {
+  border: none;
+  border-radius: 6px;
+  padding: 8px 12px;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+button#save-detection,
+button#view-saved {
+  background: #10b981;
+  color: #f8fafc;
+}
+
+button.secondary {
+  background: transparent;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  color: #cbd5f5;
+}
+
+button.danger {
+  width: 100%;
+  background: #f43f5e;
+  color: #f8fafc;
+}
+
+button.full-width {
+  width: 100%;
+  margin-bottom: 12px;
+}
+
+#status {
+  min-height: 20px;
+  font-size: 0.85rem;
+  margin-bottom: 8px;
+}
+
+#records {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+#records li {
+  background: rgba(15, 23, 42, 0.4);
+  border-radius: 6px;
+  padding: 8px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+#records .timestamp {
+  display: block;
+  color: #94a3b8;
+  font-size: 0.75rem;
+  margin-top: 4px;
+}

--- a/subtrackr-extension/utils/db.js
+++ b/subtrackr-extension/utils/db.js
@@ -1,0 +1,74 @@
+// utils/db.js
+// Lightweight IndexedDB helper tailored for SubTrackr's simple subscription records.
+
+const DB_NAME = 'subtrackrDB';
+const STORE_NAME = 'subscriptions';
+const DB_VERSION = 1;
+
+/**
+ * Opens an IndexedDB connection, creating the subscriptions store if required.
+ * @returns {Promise<IDBDatabase>} Resolves with an open database instance.
+ */
+function openDatabase() {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+    // Create the object store on initial setup or schema upgrades.
+    request.onupgradeneeded = (event) => {
+      const db = event.target.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+      }
+    };
+
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+/**
+ * Saves a subscription record, overwriting the same id if it already exists.
+ * @param {{ id: string, serviceName: string, detectedText: string, timestamp: string }} record
+ */
+export async function saveSubscription(record) {
+  const db = await openDatabase();
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, 'readwrite');
+    const store = transaction.objectStore(STORE_NAME);
+    store.put(record);
+
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error);
+  });
+}
+
+/**
+ * Retrieves every stored subscription record in insertion order.
+ * @returns {Promise<Array>}
+ */
+export async function getSubscriptions() {
+  const db = await openDatabase();
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, 'readonly');
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.getAll();
+
+    request.onsuccess = () => resolve(request.result || []);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+/**
+ * Removes all saved subscription records, giving users full control.
+ */
+export async function clearAll() {
+  const db = await openDatabase();
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, 'readwrite');
+    const store = transaction.objectStore(STORE_NAME);
+    store.clear();
+
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error);
+  });
+}


### PR DESCRIPTION
## Summary
- add a new SubTrackr Manifest V3 extension scaffold with minimal permissions and popup wiring
- implement content detection and background messaging that surfaces a save/ignore banner when subscription keywords are clicked
- provide a popup dashboard backed by IndexedDB helpers so users can review, save, and clear subscription entries

## Testing
- not run (extension code only)


------
https://chatgpt.com/codex/tasks/task_e_68e43bc8d918832fbbaecd0acde43ab0