### PR TITLE
Redesign SubTrackr popup UI and branding

### DIFF
--- a/subtrackr-extension/icons/sample-favicon.svg
+++ b/subtrackr-extension/icons/sample-favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" role="img" aria-hidden="true">
+  <rect width="32" height="32" rx="8" fill="#22C55E" />
+  <path fill="#F9FAFB" d="M21 10h-5.2a3.8 3.8 0 0 0 0 7.6H19a1.4 1.4 0 1 1 0 2.8h-5.2V23H19a4.2 4.2 0 0 0 0-8.4h-3.2a1.4 1.4 0 1 1 0-2.8H21z" />
+</svg>

--- a/subtrackr-extension/icons/subtrackr-128.svg
+++ b/subtrackr-extension/icons/subtrackr-128.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128" role="img" aria-labelledby="title">
+  <title>SubTrackr shield logo</title>
+  <defs>
+    <linearGradient id="shieldGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2563EB" />
+      <stop offset="100%" stop-color="#1D4ED8" />
+    </linearGradient>
+  </defs>
+  <path fill="url(#shieldGradient)" d="M64 8a12 12 0 0 0-4.6.9L28 22.6a8 8 0 0 0-5 7.4V61c0 27.4 18.2 52.8 43.8 61.4a8 8 0 0 0 5.4 0C97.8 113.8 116 88.4 116 61V30a8 8 0 0 0-5-7.4L68.6 8.9A12 12 0 0 0 64 8Z" />
+  <path fill="#F9FAFB" d="M84 44c0-8.84-7.16-16-16-16H56c-8.84 0-16 7.16-16 16s7.16 16 16 16h12c4.42 0 8 3.58 8 8s-3.58 8-8 8H56c-8.84 0-16 7.16-16 16s7.16 16 16 16h12c8.84 0 16-7.16 16-16H72c0 2.21-1.79 4-4 4H56c-2.21 0-4-1.79-4-4s1.79-4 4-4h12c8.84 0 16-7.16 16-16s-7.16-16-16-16H56c-2.21 0-4-1.79-4-4s1.79-4 4-4h12c2.21 0 4 1.79 4 4z" />
+</svg>

--- a/subtrackr-extension/icons/subtrackr-16.svg
+++ b/subtrackr-extension/icons/subtrackr-16.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 128 128" role="img" aria-labelledby="title">
+  <title>SubTrackr shield logo</title>
+  <defs>
+    <linearGradient id="shieldGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2563EB" />
+      <stop offset="100%" stop-color="#1D4ED8" />
+    </linearGradient>
+  </defs>
+  <path fill="url(#shieldGradient)" d="M64 8a12 12 0 0 0-4.6.9L28 22.6a8 8 0 0 0-5 7.4V61c0 27.4 18.2 52.8 43.8 61.4a8 8 0 0 0 5.4 0C97.8 113.8 116 88.4 116 61V30a8 8 0 0 0-5-7.4L68.6 8.9A12 12 0 0 0 64 8Z" />
+  <path fill="#F9FAFB" d="M84 44c0-8.84-7.16-16-16-16H56c-8.84 0-16 7.16-16 16s7.16 16 16 16h12c4.42 0 8 3.58 8 8s-3.58 8-8 8H56c-8.84 0-16 7.16-16 16s7.16 16 16 16h12c8.84 0 16-7.16 16-16H72c0 2.21-1.79 4-4 4H56c-2.21 0-4-1.79-4-4s1.79-4 4-4h12c8.84 0 16-7.16 16-16s-7.16-16-16-16H56c-2.21 0-4-1.79-4-4s1.79-4 4-4h12c2.21 0 4 1.79 4 4z" />
+</svg>

--- a/subtrackr-extension/icons/subtrackr-32.svg
+++ b/subtrackr-extension/icons/subtrackr-32.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 128 128" role="img" aria-labelledby="title">
+  <title>SubTrackr shield logo</title>
+  <defs>
+    <linearGradient id="shieldGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2563EB" />
+      <stop offset="100%" stop-color="#1D4ED8" />
+    </linearGradient>
+  </defs>
+  <path fill="url(#shieldGradient)" d="M64 8a12 12 0 0 0-4.6.9L28 22.6a8 8 0 0 0-5 7.4V61c0 27.4 18.2 52.8 43.8 61.4a8 8 0 0 0 5.4 0C97.8 113.8 116 88.4 116 61V30a8 8 0 0 0-5-7.4L68.6 8.9A12 12 0 0 0 64 8Z" />
+  <path fill="#F9FAFB" d="M84 44c0-8.84-7.16-16-16-16H56c-8.84 0-16 7.16-16 16s7.16 16 16 16h12c4.42 0 8 3.58 8 8s-3.58 8-8 8H56c-8.84 0-16 7.16-16 16s7.16 16 16 16h12c8.84 0 16-7.16 16-16H72c0 2.21-1.79 4-4 4H56c-2.21 0-4-1.79-4-4s1.79-4 4-4h12c8.84 0 16-7.16 16-16s-7.16-16-16-16H56c-2.21 0-4-1.79-4-4s1.79-4 4-4h12c2.21 0 4 1.79 4 4z" />
+</svg>

--- a/subtrackr-extension/icons/subtrackr-48.svg
+++ b/subtrackr-extension/icons/subtrackr-48.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 128 128" role="img" aria-labelledby="title">
+  <title>SubTrackr shield logo</title>
+  <defs>
+    <linearGradient id="shieldGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2563EB" />
+      <stop offset="100%" stop-color="#1D4ED8" />
+    </linearGradient>
+  </defs>
+  <path fill="url(#shieldGradient)" d="M64 8a12 12 0 0 0-4.6.9L28 22.6a8 8 0 0 0-5 7.4V61c0 27.4 18.2 52.8 43.8 61.4a8 8 0 0 0 5.4 0C97.8 113.8 116 88.4 116 61V30a8 8 0 0 0-5-7.4L68.6 8.9A12 12 0 0 0 64 8Z" />
+  <path fill="#F9FAFB" d="M84 44c0-8.84-7.16-16-16-16H56c-8.84 0-16 7.16-16 16s7.16 16 16 16h12c4.42 0 8 3.58 8 8s-3.58 8-8 8H56c-8.84 0-16 7.16-16 16s7.16 16 16 16h12c8.84 0 16-7.16 16-16H72c0 2.21-1.79 4-4 4H56c-2.21 0-4-1.79-4-4s1.79-4 4-4h12c8.84 0 16-7.16 16-16s-7.16-16-16-16H56c-2.21 0-4-1.79-4-4s1.79-4 4-4h12c2.21 0 4 1.79 4 4z" />
+</svg>

--- a/subtrackr-extension/manifest.json
+++ b/subtrackr-extension/manifest.json
@@ -3,21 +3,45 @@
   "name": "SubTrackr",
   "version": "1.0.0",
   "description": "Detect and locally track subscription-related actions without collecting personal information.",
-  "permissions": ["activeTab", "storage", "scripting"],
-  "host_permissions": ["http://*/*", "https://*/*"],
+  "permissions": [
+    "activeTab",
+    "storage",
+    "scripting"
+  ],
+  "host_permissions": [
+    "http://*/*",
+    "https://*/*"
+  ],
   "background": {
     "service_worker": "background.js",
     "type": "module"
   },
   "action": {
     "default_title": "SubTrackr",
-    "default_popup": "popup.html"
+    "default_popup": "popup.html",
+    "default_icon": {
+      "16": "icons/subtrackr-16.svg",
+      "32": "icons/subtrackr-32.svg",
+      "48": "icons/subtrackr-48.svg",
+      "128": "icons/subtrackr-128.svg"
+    }
   },
   "content_scripts": [
     {
-      "matches": ["http://*/*", "https://*/*"],
-      "js": ["content.js"],
+      "matches": [
+        "http://*/*",
+        "https://*/*"
+      ],
+      "js": [
+        "content.js"
+      ],
       "run_at": "document_idle"
     }
-  ]
+  ],
+  "icons": {
+    "16": "icons/subtrackr-16.svg",
+    "32": "icons/subtrackr-32.svg",
+    "48": "icons/subtrackr-48.svg",
+    "128": "icons/subtrackr-128.svg"
+  }
 }

--- a/subtrackr-extension/popup.html
+++ b/subtrackr-extension/popup.html
@@ -1,42 +1,179 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="light">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>SubTrackr</title>
-    <!-- Primary popup styles keep the UI compact and legible. -->
+    <!-- Inter font for the brand system. -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <!-- Primary popup styles with light/dark design tokens. -->
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <!-- Container element keeps layout consistent. -->
-    <main id="app">
-      <header>
-        <h1>SubTrackr</h1>
-        <p class="subtitle">Private subscription snapshots</p>
+    <!-- Main popup wrapper sized for a 350 × 600 viewport. -->
+    <main class="popup" role="application">
+      <!-- Header: brand identity and reassuring tagline. -->
+      <header class="popup__header card card--elevated">
+        <div class="brand">
+          <img
+            src="icons/subtrackr-48.svg"
+            width="40"
+            height="40"
+            alt="SubTrackr shield logo"
+            class="brand__logo"
+          />
+          <div class="brand__copy">
+            <h1 class="brand__title">SubTrackr</h1>
+            <p class="brand__tagline">Your subscriptions, under control — privately.</p>
+          </div>
+        </div>
+        <div class="trust-copy" role="note">
+          <strong>No sensitive data leaves your device.</strong> Everything is stored locally.
+        </div>
       </header>
 
-      <!-- Detection panel shows the latest subscription prompt when available. -->
-      <section id="detection-panel" hidden>
-        <h2>Latest detection</h2>
-        <p id="detection-message"></p>
-        <div class="actions">
-          <button id="save-detection">Save</button>
-          <button id="ignore-detection" class="secondary">Ignore</button>
+      <!-- Current tab information showing favicon and domain. -->
+      <section class="card card--surface tab-overview" aria-labelledby="tab-info-heading">
+        <div class="section-heading">
+          <h2 id="tab-info-heading">Current site</h2>
+          <span class="heading-meta">Monitored privately</span>
+        </div>
+        <div class="tab-overview__details">
+          <img
+            src="icons/sample-favicon.svg"
+            alt="Sample favicon"
+            class="tab-overview__favicon"
+            id="tab-favicon"
+            width="28"
+            height="28"
+          />
+          <div class="tab-overview__text">
+            <span class="tab-overview__domain" id="tab-domain">example.com</span>
+            <span class="tab-overview__context" id="tab-path">/pricing</span>
+          </div>
         </div>
       </section>
 
-      <!-- Status banner provides lightweight feedback after actions. -->
-      <div id="status" role="status" aria-live="polite"></div>
-
-      <!-- View saved button toggles the stored subscription list. -->
-      <button id="view-saved" class="full-width">View Saved</button>
-
-      <section id="saved-list" hidden>
-        <h2>Saved subscriptions</h2>
-        <ul id="records"></ul>
-        <button id="clear-all" class="danger">Delete All</button>
+      <!-- Detection alert card shows when keywords are found. -->
+      <section
+        class="card card--alert detection"
+        id="detection-card"
+        aria-live="polite"
+        hidden
+      >
+        <div class="section-heading">
+          <h2>Detected possible subscription</h2>
+          <span class="badge badge--accent" id="detection-keyword">keyword: "annual plan"</span>
+        </div>
+        <p class="detection__summary">
+          We spotted recurring language from <strong id="detection-service">Streamly Plus</strong>.
+          Save it for review?
+        </p>
+        <div class="detection__actions">
+          <button class="btn btn-primary" id="save-detection">Save</button>
+          <button class="btn btn-neutral" id="ignore-detection">Ignore</button>
+        </div>
       </section>
+
+      <!-- Saved subscription list with sample entries. -->
+      <section class="card card--surface" aria-labelledby="saved-heading">
+        <div class="section-heading">
+          <h2 id="saved-heading">Saved subscriptions</h2>
+          <span class="heading-meta" id="saved-count">3 tracked</span>
+        </div>
+        <div class="saved-list" role="list" id="saved-scroll">
+          <article class="saved-item sample" data-sample="true">
+            <div class="saved-item__header">
+              <h3 class="saved-item__title">Streamly Plus</h3>
+              <time class="saved-item__time" datetime="2024-04-12T10:21:00">Apr 12, 2024 · 10:21 AM</time>
+            </div>
+            <p class="saved-item__detail">Keyword match: "annual plan" — Pricing page</p>
+          </article>
+          <article class="saved-item sample" data-sample="true">
+            <div class="saved-item__header">
+              <h3 class="saved-item__title">InboxPro Mailer</h3>
+              <time class="saved-item__time" datetime="2024-04-10T19:05:00">Apr 10, 2024 · 7:05 PM</time>
+            </div>
+            <p class="saved-item__detail">Keyword match: "upgrade subscription" — Settings</p>
+          </article>
+          <article class="saved-item sample" data-sample="true">
+            <div class="saved-item__header">
+              <h3 class="saved-item__title">CloudDrive</h3>
+              <time class="saved-item__time" datetime="2024-03-30T08:44:00">Mar 30, 2024 · 8:44 AM</time>
+            </div>
+            <p class="saved-item__detail">Keyword match: "billing renewal" — Account</p>
+          </article>
+          <p class="saved-empty" id="saved-empty" hidden>No subscriptions saved yet.</p>
+        </div>
+      </section>
+
+      <!-- Footer actions for quick management. -->
+      <footer class="popup__footer">
+        <button class="btn btn-neutral" id="clear-all" type="button">Clear All</button>
+        <button class="btn btn-outline" id="open-settings" type="button">Open Settings</button>
+      </footer>
     </main>
+
+    <!-- Settings modal overlay for personalization options. -->
+    <div class="modal" id="settings-modal" hidden>
+      <div class="modal__backdrop" data-close-modal></div>
+      <div class="modal__dialog card card--surface" role="dialog" aria-modal="true" aria-labelledby="settings-title">
+        <header class="modal__header">
+          <div>
+            <h2 id="settings-title">Settings</h2>
+            <p class="modal__subtitle">Tailor SubTrackr to your workflow.</p>
+          </div>
+          <button class="icon-button" type="button" id="close-settings" aria-label="Close settings">
+            <span aria-hidden="true">×</span>
+          </button>
+        </header>
+        <form class="modal__content">
+          <label class="toggle">
+            <input type="checkbox" id="notifications-toggle" checked />
+            <span class="toggle__control" aria-hidden="true"></span>
+            <span class="toggle__label">Desktop notifications</span>
+          </label>
+
+          <label class="toggle">
+            <input type="checkbox" id="theme-toggle" />
+            <span class="toggle__control" aria-hidden="true"></span>
+            <span class="toggle__label">Dark theme</span>
+          </label>
+
+          <label class="slider" for="keyword-sensitivity">
+            <span class="slider__label">Keyword sensitivity</span>
+            <input
+              type="range"
+              id="keyword-sensitivity"
+              name="keyword-sensitivity"
+              min="1"
+              max="5"
+              value="3"
+            />
+            <div class="slider__scale" aria-hidden="true">
+              <span>Low</span>
+              <span>High</span>
+            </div>
+          </label>
+        </form>
+      </div>
+    </div>
+
+    <!-- Toast template for content script injection preview. -->
+    <template id="subtrackr-toast-template">
+      <div class="subtrackr-toast" role="status" aria-live="polite">
+        <span class="subtrackr-toast__text">SubTrackr detected subscription on this page</span>
+        <div class="subtrackr-toast__actions">
+          <button class="btn btn-primary">Save</button>
+          <button class="btn btn-neutral">Dismiss</button>
+        </div>
+      </div>
+    </template>
 
     <script type="module" src="popup.js"></script>
   </body>

--- a/subtrackr-extension/styles.css
+++ b/subtrackr-extension/styles.css
@@ -1,109 +1,613 @@
-/* styles.css
- * Minimal styling that keeps the popup uncluttered and readable.
+/*
+ * SubTrackr popup design system
+ * ---------------------------------------
+ * Contains visual design tokens, component styles, and light/dark themes
+ * for the redesigned SubTrackr popup experience.
  */
 
+/* --------------------------------------- */
+/* 1. Visual style guide (design tokens)   */
+/* --------------------------------------- */
 :root {
-  color-scheme: light dark;
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  background-color: #0f172a;
-  color: #f8fafc;
+  color-scheme: light;
+  --font-family-base: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+
+  --color-primary: #2563eb;
+  --color-primary-strong: #1d4ed8;
+  --color-accent: #22c55e;
+  --color-background: #f9fafb;
+  --color-surface: #ffffff;
+  --color-surface-alt: #f3f4f6;
+  --color-border: #e5e7eb;
+  --color-border-strong: #cbd5f5;
+  --color-text: #111827;
+  --color-text-muted: #6b7280;
+  --color-text-inverse: #f9fafb;
+
+  --shadow-soft: 0 2px 6px rgba(0, 0, 0, 0.1);
+  --shadow-elevated: 0 12px 30px rgba(15, 23, 42, 0.12);
+
+  --radius-lg: 0.75rem;
+  --radius-md: 0.65rem;
+  --radius-sm: 0.5rem;
+
+  --transition-fast: 150ms ease;
+  --transition-medium: 220ms ease;
 }
 
-body {
+html[data-theme='dark'] {
+  color-scheme: dark;
+  --color-background: #0b1220;
+  --color-surface: #111827;
+  --color-surface-alt: #1f2937;
+  --color-border: rgba(148, 163, 184, 0.3);
+  --color-border-strong: rgba(148, 163, 184, 0.6);
+  --color-text: #f9fafb;
+  --color-text-muted: #cbd5f5;
+  --color-text-inverse: #0b1220;
+  --shadow-soft: 0 2px 6px rgba(8, 15, 35, 0.5);
+  --shadow-elevated: 0 14px 40px rgba(8, 15, 35, 0.65);
+}
+
+/* Typography scale */
+h1,
+h2,
+h3 {
+  font-weight: 600;
+  color: var(--color-text);
   margin: 0;
-  min-width: 320px;
-  background: linear-gradient(160deg, #1e293b 0%, #0f172a 100%);
-}
-
-#app {
-  padding: 16px;
-}
-
-header {
-  margin-bottom: 12px;
 }
 
 h1 {
-  font-size: 1.2rem;
-  margin: 0 0 4px;
+  font-size: 1.25rem;
 }
 
-.subtitle {
+h2 {
+  font-size: 1rem;
+}
+
+h3 {
+  font-size: 0.95rem;
+}
+
+p,
+span,
+button,
+li,
+a {
+  font-family: var(--font-family-base);
+  color: var(--color-text);
+}
+
+/* --------------------------------------- */
+/* 2. Layout and base styles               */
+/* --------------------------------------- */
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--color-background);
+  color: var(--color-text);
+  font-family: var(--font-family-base);
+  -webkit-font-smoothing: antialiased;
+}
+
+.popup {
+  width: 100%;
+  max-width: 350px;
+  max-height: 600px;
+  box-sizing: border-box;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.card {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-soft);
+  padding: 1rem 1.125rem;
+  transition: opacity var(--transition-fast), transform var(--transition-fast),
+    box-shadow var(--transition-medium);
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.card--surface {
+  background: var(--color-surface-alt);
+}
+
+.card--elevated {
+  box-shadow: var(--shadow-elevated);
+}
+
+.card--alert {
+  border-color: rgba(37, 99, 235, 0.25);
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.08), transparent);
+}
+
+.section-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.heading-meta {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+
+.trust-copy {
+  margin-top: 0.75rem;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  color: var(--color-text-muted);
+}
+
+.tab-overview {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.tab-overview__details {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.tab-overview__favicon {
+  width: 2rem;
+  height: 2rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-soft);
+  background: var(--color-surface);
+}
+
+.tab-overview__domain {
+  font-weight: 600;
+}
+
+.tab-overview__context {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text-muted);
+}
+
+.badge--accent {
+  border-color: rgba(34, 197, 94, 0.35);
+  background: rgba(34, 197, 94, 0.12);
+  color: #047857;
+}
+
+.detection {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.detection__summary {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: var(--color-text);
+}
+
+.detection__actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+/* Buttons */
+.btn,
+.icon-button {
+  font-family: var(--font-family-base);
+  border: none;
+  border-radius: var(--radius-sm);
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast),
+    background-color var(--transition-fast), color var(--transition-fast);
+}
+
+.btn {
+  padding: 0.55rem 1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.btn-primary {
+  background: var(--color-primary);
+  color: var(--color-text-inverse);
+  box-shadow: var(--shadow-soft);
+}
+
+.btn-primary:hover,
+.btn-primary:focus-visible {
+  background: var(--color-primary-strong);
+}
+
+.btn-neutral {
+  background: var(--color-surface);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+}
+
+.btn-neutral:hover,
+.btn-neutral:focus-visible {
+  background: var(--color-surface-alt);
+}
+
+.btn-outline {
+  background: transparent;
+  color: var(--color-primary);
+  border: 1px solid rgba(37, 99, 235, 0.5);
+}
+
+.btn-outline:hover,
+.btn-outline:focus-visible {
+  background: rgba(37, 99, 235, 0.08);
+}
+
+.btn:focus-visible,
+.icon-button:focus-visible,
+.toggle input:focus-visible + .toggle__control {
+  outline: 3px solid rgba(37, 99, 235, 0.35);
+  outline-offset: 2px;
+}
+
+.popup__footer {
+  display: flex;
+  gap: 0.75rem;
+}
+
+/* Saved list */
+.saved-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-height: 240px;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+.saved-item {
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  transition: background var(--transition-fast), transform var(--transition-fast);
+}
+
+.saved-item:hover {
+  background: rgba(37, 99, 235, 0.04);
+  transform: translateY(-1px);
+}
+
+.saved-item__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.saved-item__title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.saved-item__time {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+
+.saved-item__detail {
   margin: 0;
   font-size: 0.85rem;
-  color: #cbd5f5;
+  color: var(--color-text-muted);
 }
 
-section {
-  background: rgba(15, 23, 42, 0.6);
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  border-radius: 8px;
-  padding: 12px;
-  margin-bottom: 12px;
+.saved-empty {
+  margin: 0;
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
 }
 
-.actions {
+/* Header styles */
+.brand {
   display: flex;
-  gap: 8px;
-  margin-top: 10px;
+  gap: 0.75rem;
+  align-items: center;
 }
 
-button {
-  border: none;
-  border-radius: 6px;
-  padding: 8px 12px;
+.brand__logo {
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-soft);
+}
+
+.brand__tagline {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+/* --------------------------------------- */
+/* 3. Modal styling                        */
+/* --------------------------------------- */
+.modal {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.5rem;
+  background: rgba(17, 24, 39, 0.35);
+  backdrop-filter: blur(4px);
+  transition: opacity var(--transition-fast);
+  z-index: 10;
+}
+
+.modal[hidden] {
+  display: none;
+}
+
+.modal__dialog {
+  max-width: 100%;
+  width: 100%;
+  gap: 1rem;
+}
+
+.modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.modal__subtitle {
+  margin: 0.25rem 0 0;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.modal__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.icon-button {
+  width: 2rem;
+  height: 2rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+}
+
+/* Toggle switches */
+.toggle {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.toggle input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.toggle__control {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: var(--color-border);
+  position: relative;
+  transition: background var(--transition-fast);
+}
+
+.toggle__control::after {
+  content: '';
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--color-surface);
+  box-shadow: var(--shadow-soft);
+  transition: transform var(--transition-fast);
+}
+
+.toggle input:checked + .toggle__control {
+  background: rgba(37, 99, 235, 0.45);
+}
+
+.toggle input:checked + .toggle__control::after {
+  transform: translateX(20px);
+}
+
+.toggle__label {
   font-size: 0.9rem;
+  color: var(--color-text);
+}
+
+/* Slider */
+.slider {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.slider__label {
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.slider input[type='range'] {
+  appearance: none;
+  height: 4px;
+  border-radius: 999px;
+  background: var(--color-border);
+}
+
+.slider input[type='range']::-webkit-slider-thumb {
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  border: none;
+  box-shadow: var(--shadow-soft);
   cursor: pointer;
 }
 
-button#save-detection,
-button#view-saved {
-  background: #10b981;
-  color: #f8fafc;
+.slider input[type='range']::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  border: none;
+  box-shadow: var(--shadow-soft);
+  cursor: pointer;
 }
 
-button.secondary {
-  background: transparent;
-  border: 1px solid rgba(148, 163, 184, 0.4);
-  color: #cbd5f5;
-}
-
-button.danger {
-  width: 100%;
-  background: #f43f5e;
-  color: #f8fafc;
-}
-
-button.full-width {
-  width: 100%;
-  margin-bottom: 12px;
-}
-
-#status {
-  min-height: 20px;
-  font-size: 0.85rem;
-  margin-bottom: 8px;
-}
-
-#records {
-  list-style: none;
-  padding: 0;
-  margin: 0;
+.slider__scale {
   display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-#records li {
-  background: rgba(15, 23, 42, 0.4);
-  border-radius: 6px;
-  padding: 8px;
-  border: 1px solid rgba(148, 163, 184, 0.2);
-}
-
-#records .timestamp {
-  display: block;
-  color: #94a3b8;
+  justify-content: space-between;
   font-size: 0.75rem;
-  margin-top: 4px;
+  color: var(--color-text-muted);
+}
+
+/* --------------------------------------- */
+/* 4. Toast preview for content injection  */
+/* --------------------------------------- */
+.subtrackr-toast {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-elevated);
+  min-width: 280px;
+  max-width: 320px;
+  animation: toast-slide-up var(--transition-medium) ease forwards;
+}
+
+.subtrackr-toast__text {
+  font-size: 0.9rem;
+  color: var(--color-text);
+}
+
+.subtrackr-toast__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+@keyframes toast-slide-up {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* --------------------------------------- */
+/* 5. Motion preferences                   */
+/* --------------------------------------- */
+@keyframes card-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.card {
+  animation: card-fade-in 200ms ease forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card,
+  .btn,
+  .subtrackr-toast {
+    animation: none;
+    transition: none;
+  }
+  .toggle__control::after {
+    transition: none;
+  }
+}
+
+/* --------------------------------------- */
+/* 6. Dark theme adjustments               */
+/* --------------------------------------- */
+html[data-theme='dark'] .badge--accent {
+  background: rgba(34, 197, 94, 0.25);
+  color: #bbf7d0;
+}
+
+html[data-theme='dark'] .saved-item:hover {
+  background: rgba(37, 99, 235, 0.12);
+}
+
+html[data-theme='dark'] .btn-neutral {
+  background: var(--color-surface);
+  border-color: var(--color-border);
+  color: var(--color-text);
+}
+
+html[data-theme='dark'] .modal {
+  background: rgba(3, 7, 18, 0.55);
+}
+
+/* Custom scrollbars */
+.saved-list::-webkit-scrollbar {
+  width: 6px;
+}
+
+.saved-list::-webkit-scrollbar-thumb {
+  background: rgba(107, 114, 128, 0.35);
+  border-radius: 999px;
+}
+
+.saved-list {
+  scrollbar-color: rgba(107, 114, 128, 0.35) transparent;
 }


### PR DESCRIPTION
## Summary
- rebuild the popup layout with a trust-focused header, detection card, saved subscription feed, and settings modal using new design tokens
- add a light/dark theming system, reusable button and badge styles, and a toast template for the content overlay
- refresh the content script toast styling/animation and register the new shield icons across manifest assets

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e43fe13080832f916db7fa8628a7b2